### PR TITLE
Add newsletter localization entries for English and Norwegian

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -55,10 +55,15 @@
       "next_slide": "Slide right",
       "previous_slide": "Slide left",
       "name": "Slider"
+    },
+    "newsletter_form": {
+      "error": "There was an error subscribing. Please try again."
     }
   },
   "newsletter": {
     "label": "Email",
+    "placeholder": "Enter your email",
+    "cta": "Join our newsletter",
     "success": "Thanks for subscribing",
     "button_label": "Subscribe"
   },

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -55,10 +55,15 @@
       "next_slide": "Bla til høyre",
       "previous_slide": "Bla til venstre",
       "name": "Glidefelt"
+    },
+    "newsletter_form": {
+      "error": "Noe gikk galt. Prøv igjen."
     }
   },
   "newsletter": {
     "label": "E-post",
+    "placeholder": "Skriv inn e-postadressen din",
+    "cta": "Bli med på nyhetsbrevet vårt",
     "success": "Takk for at du abonnerer",
     "button_label": "Abonner"
   },


### PR DESCRIPTION
## Summary
- add newsletter placeholder and CTA text to the English and Norwegian locale files
- provide a localized newsletter form error message in both languages to keep the locales aligned

## Testing
- jq . locales/en.default.json
- jq . locales/nb.json

------
https://chatgpt.com/codex/tasks/task_e_68ddae4257a48328ac367ab8a55d40da