### PR TITLE
Adjust newsletter spacing around customer club callout

### DIFF
--- a/blocks/ai_gen_block_7f82874.liquid
+++ b/blocks/ai_gen_block_7f82874.liquid
@@ -249,7 +249,7 @@
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 12px;
-    padding: 0 15px 15px;
+    padding: 20px 15px 15px;
     margin-top: {{ block.settings.newsletter_margin_top }}px;
     transition: all 0.3s ease;
     position: relative;
@@ -257,7 +257,7 @@
   }
 
   .kk-newsletter__body {
-    padding-top: 15px;
+    padding-top: 8px;
   }
 
   .kk-newsletter:hover {


### PR DESCRIPTION
## Summary
- increase the top padding inside the newsletter card so the heading has more breathing room
- reduce the padding before the customer club content so the icon sits closer to the “Bli med i klubben!” heading

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddc3a7415883288504d026cf10b6ab