### PR TITLE
Update footer success styling and add extra policy links

### DIFF
--- a/blocks/comprehensive-footer.liquid
+++ b/blocks/comprehensive-footer.liquid
@@ -443,7 +443,7 @@
   }
 
   .kk-msg--success {
-    color: #4ade80;
+    color: #121314;
   }
 
   .kk-msg--error {
@@ -744,7 +744,7 @@
                     })
                       .then(function() {
                         if (messageContainer) {
-                          messageContainer.innerHTML = '<p class="kk-msg--success">🎉 Du er nå med i KUL KID Kundeklubb! Sjekk innboksen din for 15 % rabattkode.</p>';
+                          messageContainer.innerHTML = '<p class="kk-msg--success" style="color:#121314;">🎉 Du er nå med i KUL KID Kundeklubb! Sjekk innboksen din for 15 % rabattkode.</p>';
                         }
                         form.reset();
                       })
@@ -915,7 +915,25 @@
         <a href="{{ shop.subscription_policy.url }}">{{ shop.subscription_policy.title }}</a>
         {% assign policy_count = policy_count | plus: 1 %}
       {% endif %}
-      
+
+      {% if block.settings.cookie_preferences_link != blank %}
+        {% if policy_count > 0 %}<span class="ai-footer-policy-separator-{{ ai_gen_id }}">•</span>{% endif %}
+        <a href="{{ block.settings.cookie_preferences_link }}">Informasjonskapsler</a>
+        {% assign policy_count = policy_count | plus: 1 %}
+      {% endif %}
+
+      {% if block.settings.contact_info_link != blank %}
+        {% if policy_count > 0 %}<span class="ai-footer-policy-separator-{{ ai_gen_id }}">•</span>{% endif %}
+        <a href="{{ block.settings.contact_info_link }}">Kontaktinformasjon</a>
+        {% assign policy_count = policy_count | plus: 1 %}
+      {% endif %}
+
+      {% if block.settings.legal_notice_link != blank %}
+        {% if policy_count > 0 %}<span class="ai-footer-policy-separator-{{ ai_gen_id }}">•</span>{% endif %}
+        <a href="{{ block.settings.legal_notice_link }}">Juridisk informasjon</a>
+        {% assign policy_count = policy_count | plus: 1 %}
+      {% endif %}
+
       {% if block.settings.show_cookie_preferences %}
         {% if policy_count > 0 %}<span class="ai-footer-policy-separator-{{ ai_gen_id }}">•</span>{% endif %}
         <button type="button" onclick="window.Shopify.customerPrivacy.setTrackingConsent(false, function() { location.reload(); });">Cookie preferences</button>
@@ -1631,6 +1649,25 @@
       "id": "show_cookie_preferences",
       "label": "Show cookie preferences",
       "default": true
+    },
+    {
+      "type": "header",
+      "content": "Flere policy-lenker"
+    },
+    {
+      "type": "url",
+      "id": "cookie_preferences_link",
+      "label": "Lenke til informasjonskapsler (Cookie Preferences)"
+    },
+    {
+      "type": "url",
+      "id": "contact_info_link",
+      "label": "Lenke til kontaktinformasjon"
+    },
+    {
+      "type": "url",
+      "id": "legal_notice_link",
+      "label": "Lenke til juridisk informasjon"
     },
     {
       "type": "header",


### PR DESCRIPTION
## Summary
- ensure the Klaviyo footer signup success message displays in Norwegian with the requested black color styling
- add optional cookie, contact, and legal policy links that render with the existing separator styling when configured

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5abd632b883289eb45c7b75b35fd8