### PR TITLE
Refine overlay header icon hover animation

### DIFF
--- a/blocks/comprehensive-overlay-header.liquid
+++ b/blocks/comprehensive-overlay-header.liquid
@@ -182,35 +182,83 @@
   }
 
   .ai-overlay-header-icon-{{ ai_gen_id }} {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: {{ block.settings.icon_size_mobile }}px;
     height: {{ block.settings.icon_size_mobile }}px;
     cursor: pointer;
-    transition: color 0.3s ease;
     margin: {{ block.settings.icon_margin }}px;
-  }
-
-  .ai-overlay-header-search-icon-{{ ai_gen_id }} {
     color: {{ block.settings.search_icon_color_mobile }};
-  }
-
-  .ai-overlay-header-search-icon-{{ ai_gen_id }}:hover {
-    color: {{ block.settings.search_icon_hover_color_mobile }};
+    transition: color 0.35s ease;
   }
 
   .ai-overlay-header-account-icon-{{ ai_gen_id }} {
     color: {{ block.settings.account_icon_color_mobile }};
   }
 
-  .ai-overlay-header-account-icon-{{ ai_gen_id }}:hover {
-    color: {{ block.settings.account_icon_hover_color_mobile }};
-  }
-
   .ai-overlay-header-cart-icon-{{ ai_gen_id }} {
     color: {{ block.settings.cart_icon_color_mobile }};
   }
 
-  .ai-overlay-header-cart-icon-{{ ai_gen_id }}:hover {
-    color: {{ block.settings.cart_icon_hover_color_mobile }};
+  .ai-overlay-header-icon-{{ ai_gen_id }} svg,
+  .ai-overlay-header-icon-{{ ai_gen_id }} img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    transition: transform 0.35s ease;
+  }
+
+  .ai-overlay-header-icon-{{ ai_gen_id }} svg * {
+    transition: fill 0.35s ease, stroke 0.35s ease;
+  }
+
+  .ai-overlay-header-icon-{{ ai_gen_id }} svg [fill]:not([fill='none']) {
+    fill: currentColor;
+  }
+
+  .ai-overlay-header-icon-{{ ai_gen_id }} svg [stroke]:not([stroke='none']) {
+    stroke: currentColor;
+  }
+
+  .ai-overlay-header-icon-{{ ai_gen_id }}.ai-rainbow-active svg [fill]:not([fill='none']) {
+    fill: url(#ai-rainbow-icon-gradient-{{ ai_gen_id }});
+  }
+
+  .ai-overlay-header-icon-{{ ai_gen_id }}.ai-rainbow-active svg [stroke]:not([stroke='none']) {
+    stroke: url(#ai-rainbow-icon-gradient-{{ ai_gen_id }});
+  }
+
+  .ai-overlay-header-icon-{{ ai_gen_id }}.ai-rainbow-active svg {
+    transform: scale(1.05);
+  }
+
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop {
+    animation: ai-overlay-header-gradient-shift-{{ ai_gen_id }} 1.2s linear infinite;
+    animation-play-state: paused;
+  }
+
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(2) { animation-delay: -0.1s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(3) { animation-delay: -0.2s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(4) { animation-delay: -0.3s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(5) { animation-delay: -0.4s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(6) { animation-delay: -0.5s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(7) { animation-delay: -0.6s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(8) { animation-delay: -0.7s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(9) { animation-delay: -0.8s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(10) { animation-delay: -0.9s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(11) { animation-delay: -1s; }
+  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(12) { animation-delay: -1.1s; }
+
+  .ai-overlay-header-gradient-{{ ai_gen_id }}.ai-animate stop {
+    animation-play-state: running;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ai-overlay-header-gradient-{{ ai_gen_id }} stop {
+      animation: none;
+    }
   }
 
   .ai-overlay-header-hamburger-{{ ai_gen_id }} {
@@ -372,29 +420,6 @@
     border-top: 1px solid {{ block.settings.dropdown_border_color }};
   }
 
-  .ai-overlay-header-mobile-icons-{{ ai_gen_id }} .ai-overlay-header-search-icon-{{ ai_gen_id }} {
-    color: {{ block.settings.search_icon_color_mobile }};
-  }
-
-  .ai-overlay-header-mobile-icons-{{ ai_gen_id }} .ai-overlay-header-search-icon-{{ ai_gen_id }}:hover {
-    color: {{ block.settings.search_icon_hover_color_mobile }};
-  }
-
-  .ai-overlay-header-mobile-icons-{{ ai_gen_id }} .ai-overlay-header-account-icon-{{ ai_gen_id }} {
-    color: {{ block.settings.account_icon_color_mobile }};
-  }
-
-  .ai-overlay-header-mobile-icons-{{ ai_gen_id }} .ai-overlay-header-account-icon-{{ ai_gen_id }}:hover {
-    color: {{ block.settings.account_icon_hover_color_mobile }};
-  }
-
-  .ai-overlay-header-mobile-icons-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }} {
-    color: {{ block.settings.cart_icon_color_mobile }};
-  }
-
-  .ai-overlay-header-mobile-icons-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:hover {
-    color: {{ block.settings.cart_icon_hover_color_mobile }};
-  }
 
   @keyframes ai-rainbow-underline-{{ ai_gen_id }} {
     0% { background-position: 0% 50%; }
@@ -404,6 +429,22 @@
   @keyframes ai-rainbow-press-{{ ai_gen_id }} {
     0% { background-position: 0% 50%; }
     100% { background-position: 200% 50%; }
+  }
+
+  @keyframes ai-overlay-header-gradient-shift-{{ ai_gen_id }} {
+    0% { stop-color: #ff0000; }
+    8.33% { stop-color: #ff8000; }
+    16.66% { stop-color: #ffff00; }
+    25% { stop-color: #80ff00; }
+    33.33% { stop-color: #00ff00; }
+    41.66% { stop-color: #00ff80; }
+    50% { stop-color: #00ffff; }
+    58.33% { stop-color: #0080ff; }
+    66.66% { stop-color: #0000ff; }
+    75% { stop-color: #8000ff; }
+    83.33% { stop-color: #ff00ff; }
+    91.66% { stop-color: #ff0080; }
+    100% { stop-color: #ff0000; }
   }
 
   @media screen and (min-width: 750px) {
@@ -426,45 +467,7 @@
 
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} {
       display: flex;
-      --ai-cart-hover-color: {{ block.settings.cart_icon_hover_color_desktop | default: block.settings.cart_icon_color_desktop | default: '#ffffff' }};
-      --ai-cart-hover-gradient: linear-gradient(
-        90deg,
-        #ff0000,
-        #ff8000,
-        #ffff00,
-        #80ff00,
-        #00ff00,
-        #00ff80,
-        #00ffff,
-        #0080ff,
-        #0000ff,
-        #8000ff,
-        #ff00ff,
-        #ff0080
-      );
     }
-
-    {% if block.settings.cart_icon_hover_color_desktop != blank %}
-      @supports (color: color-mix(in srgb, red, blue)) {
-        .ai-overlay-header-actions-desktop-{{ ai_gen_id }} {
-          --ai-cart-hover-gradient: linear-gradient(
-            90deg,
-            color-mix(in srgb, var(--ai-cart-hover-color) 70%, #ff0000 30%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 65%, #ff8000 35%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 60%, #ffff00 40%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 58%, #80ff00 42%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 55%, #00ff00 45%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 52%, #00ff80 48%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 50%, #00ffff 50%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 52%, #0080ff 48%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 55%, #0000ff 45%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 58%, #8000ff 42%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 62%, #ff00ff 38%),
-            color-mix(in srgb, var(--ai-cart-hover-color) 66%, #ff0080 34%)
-          );
-        }
-      }
-    {% endif %}
 
     .ai-overlay-header-icon-{{ ai_gen_id }} {
       width: {{ block.settings.icon_size_desktop }}px;
@@ -483,95 +486,33 @@
       color: {{ block.settings.account_icon_color_desktop }};
     }
 
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} svg,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} img {
-      transition: transform 0.3s ease, filter 0.3s ease;
-      display: block;
-    }
-
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} svg path,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} svg circle,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} svg rect,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} svg polygon {
-      transition: fill 0.3s ease;
-    }
-
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-search-icon-{{ ai_gen_id }} {
       color: {{ block.settings.search_icon_color_desktop }};
     }
 
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover {
-      color: inherit;
-    }
-
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg path,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg circle,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg rect,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg polygon {
-      fill: url(#ai-rainbow-gradient-{{ ai_gen_id }});
-    }
-
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }}:hover img {
-      transform: scale(1.05);
-      filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.4));
-    }
-
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }} {
-      position: relative;
       color: {{ block.settings.cart_icon_color_desktop }};
-      transition: color 0.3s ease;
     }
 
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:hover,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:focus-visible {
-      color: var(--ai-cart-hover-color);
-    }
-
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}::after {
-      content: '';
-      position: absolute;
-      left: 20%;
-      right: 20%;
-      bottom: -0.5rem;
-      height: 0.2rem;
-      border-radius: 999px;
-      background-image: var(--ai-cart-hover-gradient);
-      background-size: 200% 100%;
-      opacity: 0;
-      transform: scaleX(0.4);
-      transform-origin: center;
-      transition: opacity 0.3s ease, transform 0.3s ease;
-    }
-
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:hover::after,
-    .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:focus-visible::after {
-      opacity: 1;
-      transform: scaleX(1);
-      animation: ai-rainbow-underline-{{ ai_gen_id }} 1.6s linear infinite;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:hover::after,
-      .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }}:focus-visible::after {
-        animation: none;
-      }
-    }
   }
 {% endstyle %}
 
 <overlay-header-{{ ai_gen_id }} class="ai-overlay-header-{{ ai_gen_id }}" {{ block.shopify_attributes }}>
   <svg style="display: none;">
     <defs>
-      <linearGradient id="ai-rainbow-gradient-{{ ai_gen_id }}" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" style="stop-color:#ff0000"/>
-        <stop offset="14%" style="stop-color:#ff8000"/>
-        <stop offset="28%" style="stop-color:#ffff00"/>
-        <stop offset="42%" style="stop-color:#80ff00"/>
-        <stop offset="57%" style="stop-color:#00ff00"/>
-        <stop offset="71%" style="stop-color:#00ff80"/>
-        <stop offset="85%" style="stop-color:#00ffff"/>
-        <stop offset="100%" style="stop-color:#0080ff"/>
+      <linearGradient id="ai-rainbow-icon-gradient-{{ ai_gen_id }}" x1="0%" y1="0%" x2="100%" y2="0%" class="ai-overlay-header-gradient-{{ ai_gen_id }}">
+        <stop offset="0%" stop-color="#ff0000" />
+        <stop offset="9%" stop-color="#ff8000" />
+        <stop offset="18%" stop-color="#ffff00" />
+        <stop offset="27%" stop-color="#80ff00" />
+        <stop offset="36%" stop-color="#00ff00" />
+        <stop offset="45%" stop-color="#00ff80" />
+        <stop offset="54%" stop-color="#00ffff" />
+        <stop offset="63%" stop-color="#0080ff" />
+        <stop offset="72%" stop-color="#0000ff" />
+        <stop offset="81%" stop-color="#8000ff" />
+        <stop offset="90%" stop-color="#ff00ff" />
+        <stop offset="100%" stop-color="#ff0080" />
       </linearGradient>
     </defs>
   </svg>
@@ -731,6 +672,10 @@
         this.overlay = this.querySelector('.ai-overlay-header-mobile-overlay-{{ ai_gen_id }}');
         this.mobileNavLinks = this.querySelectorAll('.ai-overlay-header-mobile-nav-link-{{ ai_gen_id }}[data-has-dropdown="true"]');
         this.headerContainer = this.querySelector('.ai-overlay-header-container-{{ ai_gen_id }}');
+        this.iconGradient = this.querySelector('#ai-rainbow-icon-gradient-{{ ai_gen_id }}');
+        this.headerIcons = Array.from(this.querySelectorAll('.ai-overlay-header-icon-{{ ai_gen_id }}'));
+        this.activeIconCount = 0;
+        this.iconCleanupHandlers = [];
         this.updateOverlayOffset = this.updateOverlayOffset.bind(this);
         if (this.hamburger) {
           this.hamburger.setAttribute('aria-expanded', 'false');
@@ -739,6 +684,7 @@
 
       connectedCallback() {
         this.setupEventListeners();
+        this.setupIconGradient();
         this.updateOverlayOffset();
         window.addEventListener('resize', this.updateOverlayOffset);
         window.addEventListener('scroll', this.updateOverlayOffset, { passive: true });
@@ -747,6 +693,7 @@
       disconnectedCallback() {
         window.removeEventListener('resize', this.updateOverlayOffset);
         window.removeEventListener('scroll', this.updateOverlayOffset);
+        this.teardownIconGradient();
       }
 
       setupEventListeners() {
@@ -776,6 +723,86 @@
             this.closeMobileMenu();
           }
         });
+      }
+
+      setupIconGradient() {
+        if (!this.iconGradient || !this.headerIcons.length) {
+          return;
+        }
+
+        const startGradient = () => {
+          this.activeIconCount += 1;
+          if (this.activeIconCount === 1) {
+            this.iconGradient.classList.add('ai-animate');
+          }
+        };
+
+        const stopGradient = () => {
+          this.activeIconCount = Math.max(0, this.activeIconCount - 1);
+          if (this.activeIconCount === 0) {
+            this.iconGradient.classList.remove('ai-animate');
+          }
+        };
+
+        this.headerIcons.forEach((icon) => {
+          const svg = icon.querySelector('svg');
+          if (!svg) {
+            return;
+          }
+
+          const activate = () => {
+            if (!icon.classList.contains('ai-rainbow-active')) {
+              icon.classList.add('ai-rainbow-active');
+              startGradient();
+            }
+          };
+
+          const deactivate = () => {
+            if (icon.classList.contains('ai-rainbow-active')) {
+              icon.classList.remove('ai-rainbow-active');
+              stopGradient();
+            }
+          };
+
+          const touchHandler = () => {
+            activate();
+            if (icon._aiTouchTimeout) {
+              clearTimeout(icon._aiTouchTimeout);
+            }
+            icon._aiTouchTimeout = setTimeout(() => {
+              deactivate();
+              icon._aiTouchTimeout = null;
+            }, 400);
+          };
+
+          icon.addEventListener('mouseenter', activate);
+          icon.addEventListener('mouseleave', deactivate);
+          icon.addEventListener('focus', activate);
+          icon.addEventListener('blur', deactivate);
+          icon.addEventListener('touchstart', touchHandler, { passive: true });
+
+          this.iconCleanupHandlers.push(() => {
+            icon.removeEventListener('mouseenter', activate);
+            icon.removeEventListener('mouseleave', deactivate);
+            icon.removeEventListener('focus', activate);
+            icon.removeEventListener('blur', deactivate);
+            icon.removeEventListener('touchstart', touchHandler);
+            if (icon._aiTouchTimeout) {
+              clearTimeout(icon._aiTouchTimeout);
+              icon._aiTouchTimeout = null;
+            }
+            icon.classList.remove('ai-rainbow-active');
+          });
+        });
+      }
+
+      teardownIconGradient() {
+        this.iconCleanupHandlers.forEach((cleanup) => cleanup());
+        this.iconCleanupHandlers = [];
+        this.activeIconCount = 0;
+        if (this.iconGradient) {
+          this.iconGradient.classList.remove('ai-animate');
+        }
       }
 
       toggleMobileMenu() {


### PR DESCRIPTION
## Summary
- restyle overlay header icons to drop underline effects and keep theme colors at rest
- add reusable rainbow gradient definition with motion preferences for icon hover states
- wire up JavaScript hover/focus handlers so SVG icons animate with the rainbow gradient

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5b64f4b748328a1dea423bd82e5ac