### PR TITLE
Apply rainbow gradient hover to overlay header icons

### DIFF
--- a/blocks/comprehensive-overlay-header.liquid
+++ b/blocks/comprehensive-overlay-header.liquid
@@ -195,7 +195,7 @@
     --ai-overlay-header-icon-base-color: {{ block.settings.search_icon_color_mobile }};
     color: var(--ai-overlay-header-icon-base-color);
     text-decoration: none;
-    transition: color var(--ai-overlay-header-rainbow-transition);
+    transition: transform var(--ai-overlay-header-rainbow-transition);
   }
 
   .ai-overlay-header-account-icon-{{ ai_gen_id }} {
@@ -220,24 +220,12 @@
     transition: fill var(--ai-overlay-header-rainbow-transition), stroke var(--ai-overlay-header-rainbow-transition);
   }
 
-  .ai-overlay-header-icon-{{ ai_gen_id }}:not(.ai-rainbow-active) svg [fill]:not([fill='none']) {
+  .ai-overlay-header-icon-{{ ai_gen_id }} svg [fill]:not([fill='none']) {
     fill: currentColor;
   }
 
-  .ai-overlay-header-icon-{{ ai_gen_id }}:not(.ai-rainbow-active) svg [stroke]:not([stroke='none']) {
+  .ai-overlay-header-icon-{{ ai_gen_id }} svg [stroke]:not([stroke='none']) {
     stroke: currentColor;
-  }
-
-  .ai-overlay-header-icon-{{ ai_gen_id }}.ai-rainbow-active svg [fill]:not([fill='none']) {
-    fill: url(#ai-rainbow-icon-gradient-{{ ai_gen_id }}) !important;
-  }
-
-  .ai-overlay-header-icon-{{ ai_gen_id }}.ai-rainbow-active svg [stroke]:not([stroke='none']) {
-    stroke: url(#ai-rainbow-icon-gradient-{{ ai_gen_id }}) !important;
-  }
-
-  .ai-overlay-header-icon-{{ ai_gen_id }}.ai-rainbow-active svg {
-    transform: scale(1.05);
   }
 
   .ai-overlay-header-icon-{{ ai_gen_id }}::after {
@@ -250,33 +238,28 @@
   .ai-overlay-header-icon-{{ ai_gen_id }}:active {
     color: var(--ai-overlay-header-icon-base-color);
     outline: none;
+    text-decoration: none;
   }
 
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop {
-    animation: ai-overlay-header-gradient-shift-{{ ai_gen_id }} 1.2s linear infinite;
-    animation-play-state: paused;
+  .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg,
+  .ai-overlay-header-icon-{{ ai_gen_id }}:focus svg,
+  .ai-overlay-header-icon-{{ ai_gen_id }}:focus-visible svg,
+  .ai-overlay-header-icon-{{ ai_gen_id }}:active svg {
+    transform: scale(1.05);
   }
 
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(2) { animation-delay: -0.1s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(3) { animation-delay: -0.2s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(4) { animation-delay: -0.3s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(5) { animation-delay: -0.4s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(6) { animation-delay: -0.5s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(7) { animation-delay: -0.6s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(8) { animation-delay: -0.7s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(9) { animation-delay: -0.8s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(10) { animation-delay: -0.9s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(11) { animation-delay: -1s; }
-  .ai-overlay-header-gradient-{{ ai_gen_id }} stop:nth-child(12) { animation-delay: -1.1s; }
-
-  .ai-overlay-header-gradient-{{ ai_gen_id }}.ai-animate stop {
-    animation-play-state: running;
+  .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg [fill]:not([fill='none']),
+  .ai-overlay-header-icon-{{ ai_gen_id }}:focus svg [fill]:not([fill='none']),
+  .ai-overlay-header-icon-{{ ai_gen_id }}:focus-visible svg [fill]:not([fill='none']),
+  .ai-overlay-header-icon-{{ ai_gen_id }}:active svg [fill]:not([fill='none']) {
+    fill: url(#rainbow-gradient);
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .ai-overlay-header-gradient-{{ ai_gen_id }} stop {
-      animation: none;
-    }
+  .ai-overlay-header-icon-{{ ai_gen_id }}:hover svg [stroke]:not([stroke='none']),
+  .ai-overlay-header-icon-{{ ai_gen_id }}:focus svg [stroke]:not([stroke='none']),
+  .ai-overlay-header-icon-{{ ai_gen_id }}:focus-visible svg [stroke]:not([stroke='none']),
+  .ai-overlay-header-icon-{{ ai_gen_id }}:active svg [stroke]:not([stroke='none']) {
+    stroke: url(#rainbow-gradient);
   }
 
   .ai-overlay-header-hamburger-{{ ai_gen_id }} {
@@ -449,22 +432,6 @@
     100% { background-position: 200% 50%; }
   }
 
-  @keyframes ai-overlay-header-gradient-shift-{{ ai_gen_id }} {
-    0% { stop-color: #ff0000; }
-    8.33% { stop-color: #ff8000; }
-    16.66% { stop-color: #ffff00; }
-    25% { stop-color: #80ff00; }
-    33.33% { stop-color: #00ff00; }
-    41.66% { stop-color: #00ff80; }
-    50% { stop-color: #00ffff; }
-    58.33% { stop-color: #0080ff; }
-    66.66% { stop-color: #0000ff; }
-    75% { stop-color: #8000ff; }
-    83.33% { stop-color: #ff00ff; }
-    91.66% { stop-color: #ff0080; }
-    100% { stop-color: #ff0000; }
-  }
-
   @media screen and (min-width: 750px) {
     .ai-overlay-header-container-{{ ai_gen_id }} {
       padding: {{ block.settings.header_margin_desktop }}px;
@@ -520,9 +487,9 @@
 {% endstyle %}
 
 <overlay-header-{{ ai_gen_id }} class="ai-overlay-header-{{ ai_gen_id }}" {{ block.shopify_attributes }}>
-  <svg style="display: none;">
+  <svg style="display: none;" aria-hidden="true" focusable="false">
     <defs>
-      <linearGradient id="ai-rainbow-icon-gradient-{{ ai_gen_id }}" x1="0%" y1="0%" x2="100%" y2="0%" class="ai-overlay-header-gradient-{{ ai_gen_id }}">
+      <linearGradient id="rainbow-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
         <stop offset="0%" stop-color="#ff0000" />
         <stop offset="9%" stop-color="#ff8000" />
         <stop offset="18%" stop-color="#ffff00" />
@@ -694,10 +661,6 @@
         this.overlay = this.querySelector('.ai-overlay-header-mobile-overlay-{{ ai_gen_id }}');
         this.mobileNavLinks = this.querySelectorAll('.ai-overlay-header-mobile-nav-link-{{ ai_gen_id }}[data-has-dropdown="true"]');
         this.headerContainer = this.querySelector('.ai-overlay-header-container-{{ ai_gen_id }}');
-        this.iconGradient = this.querySelector('#ai-rainbow-icon-gradient-{{ ai_gen_id }}');
-        this.headerIcons = Array.from(this.querySelectorAll('.ai-overlay-header-icon-{{ ai_gen_id }}'));
-        this.activeIconCount = 0;
-        this.iconCleanupHandlers = [];
         this.updateOverlayOffset = this.updateOverlayOffset.bind(this);
         if (this.hamburger) {
           this.hamburger.setAttribute('aria-expanded', 'false');
@@ -706,7 +669,6 @@
 
       connectedCallback() {
         this.setupEventListeners();
-        this.setupIconGradient();
         this.updateOverlayOffset();
         window.addEventListener('resize', this.updateOverlayOffset);
         window.addEventListener('scroll', this.updateOverlayOffset, { passive: true });
@@ -715,7 +677,6 @@
       disconnectedCallback() {
         window.removeEventListener('resize', this.updateOverlayOffset);
         window.removeEventListener('scroll', this.updateOverlayOffset);
-        this.teardownIconGradient();
       }
 
       setupEventListeners() {
@@ -745,86 +706,6 @@
             this.closeMobileMenu();
           }
         });
-      }
-
-      setupIconGradient() {
-        if (!this.iconGradient || !this.headerIcons.length) {
-          return;
-        }
-
-        const startGradient = () => {
-          this.activeIconCount += 1;
-          if (this.activeIconCount === 1) {
-            this.iconGradient.classList.add('ai-animate');
-          }
-        };
-
-        const stopGradient = () => {
-          this.activeIconCount = Math.max(0, this.activeIconCount - 1);
-          if (this.activeIconCount === 0) {
-            this.iconGradient.classList.remove('ai-animate');
-          }
-        };
-
-        this.headerIcons.forEach((icon) => {
-          const svg = icon.querySelector('svg');
-          if (!svg) {
-            return;
-          }
-
-          const activate = () => {
-            if (!icon.classList.contains('ai-rainbow-active')) {
-              icon.classList.add('ai-rainbow-active');
-              startGradient();
-            }
-          };
-
-          const deactivate = () => {
-            if (icon.classList.contains('ai-rainbow-active')) {
-              icon.classList.remove('ai-rainbow-active');
-              stopGradient();
-            }
-          };
-
-          const touchHandler = () => {
-            activate();
-            if (icon._aiTouchTimeout) {
-              clearTimeout(icon._aiTouchTimeout);
-            }
-            icon._aiTouchTimeout = setTimeout(() => {
-              deactivate();
-              icon._aiTouchTimeout = null;
-            }, 400);
-          };
-
-          icon.addEventListener('mouseenter', activate);
-          icon.addEventListener('mouseleave', deactivate);
-          icon.addEventListener('focus', activate);
-          icon.addEventListener('blur', deactivate);
-          icon.addEventListener('touchstart', touchHandler, { passive: true });
-
-          this.iconCleanupHandlers.push(() => {
-            icon.removeEventListener('mouseenter', activate);
-            icon.removeEventListener('mouseleave', deactivate);
-            icon.removeEventListener('focus', activate);
-            icon.removeEventListener('blur', deactivate);
-            icon.removeEventListener('touchstart', touchHandler);
-            if (icon._aiTouchTimeout) {
-              clearTimeout(icon._aiTouchTimeout);
-              icon._aiTouchTimeout = null;
-            }
-            icon.classList.remove('ai-rainbow-active');
-          });
-        });
-      }
-
-      teardownIconGradient() {
-        this.iconCleanupHandlers.forEach((cleanup) => cleanup());
-        this.iconCleanupHandlers = [];
-        this.activeIconCount = 0;
-        if (this.iconGradient) {
-          this.iconGradient.classList.remove('ai-animate');
-        }
       }
 
       toggleMobileMenu() {


### PR DESCRIPTION
## Summary
- inject a shared rainbow gradient definition and apply it to header icon SVGs on hover using stroke and fill
- drop the gradient animation scripting and ensure icon hover states keep the schema base colors without underline effects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5bc5dc5548328a37e1718f51246c0