### PR TITLE
Fix overlay header icon hover gradient animation

### DIFF
--- a/blocks/comprehensive-overlay-header.liquid
+++ b/blocks/comprehensive-overlay-header.liquid
@@ -207,6 +207,7 @@
     cursor: pointer;
     margin: {{ block.settings.icon_margin }}px;
     --ai-overlay-header-icon-base-color: {{ block.settings.search_icon_color_mobile }};
+    --icon-base: var(--ai-overlay-header-icon-base-color);
     color: var(--ai-overlay-header-icon-base-color);
     text-decoration: none;
     transition: color var(--ai-overlay-header-rainbow-transition);
@@ -214,11 +215,13 @@
 
   .ai-overlay-header-account-icon-{{ ai_gen_id }} {
     --ai-overlay-header-icon-base-color: {{ block.settings.account_icon_color_mobile }};
+    --icon-base: var(--ai-overlay-header-icon-base-color);
     color: var(--ai-overlay-header-icon-base-color);
   }
 
   .ai-overlay-header-cart-icon-{{ ai_gen_id }} {
     --ai-overlay-header-icon-base-color: {{ block.settings.cart_icon_color_mobile }};
+    --icon-base: var(--ai-overlay-header-icon-base-color);
     color: var(--ai-overlay-header-icon-base-color);
   }
 
@@ -228,14 +231,6 @@
     height: 100%;
     display: block;
     transition: transform var(--ai-overlay-header-rainbow-transition);
-  }
-
-  .ai-overlay-header-icon-{{ ai_gen_id }} svg [fill]:not([fill='none']) {
-    fill: currentColor;
-  }
-
-  .ai-overlay-header-icon-{{ ai_gen_id }} svg [stroke]:not([stroke='none']) {
-    stroke: currentColor;
   }
 
   .ai-overlay-header-icon-{{ ai_gen_id }}::after {
@@ -248,20 +243,12 @@
 
   .ai-overlay-header-{{ ai_gen_id }} .header__icon .icon-wrapper {
     display: inline-block;
-    color: inherit;
-    transition: transform 0.25s ease, color 0.35s ease;
+    transition: transform 0.25s ease;
   }
 
   .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover .icon-wrapper,
   .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus .icon-wrapper,
   .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible .icon-wrapper {
-    background: var(--ai-overlay-header-rainbow-gradient);
-    background-size: 200% auto;
-    animation: rainbow-slide 2s linear infinite;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    color: transparent;
     transform: translateY(-1px);
   }
 
@@ -283,6 +270,50 @@
   .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus .icon-wrapper img,
   .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible .icon-wrapper img {
     transform: scale(1.05);
+  }
+
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible {
+    color: var(--icon-base, var(--ai-overlay-header-icon-base-color, inherit)) !important;
+  }
+
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon svg path,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon svg rect,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon svg circle,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon svg polygon,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon svg polyline {
+    fill: var(--icon-base, var(--ai-overlay-header-icon-base-color, #121212));
+    transition: fill var(--ai-overlay-header-rainbow-transition);
+  }
+
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon svg [stroke]:not([stroke='none']) {
+    stroke: var(--icon-base, var(--ai-overlay-header-icon-base-color, #121212));
+    transition: stroke var(--ai-overlay-header-rainbow-transition);
+  }
+
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover svg path,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus svg path,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible svg path,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover svg rect,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus svg rect,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible svg rect,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover svg circle,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus svg circle,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible svg circle,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover svg polygon,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus svg polygon,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible svg polygon,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover svg polyline,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus svg polyline,
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible svg polyline {
+    fill: url(#rainbow-gradient) !important;
+  }
+
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:hover svg [stroke]:not([stroke='none']),
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus svg [stroke]:not([stroke='none']),
+  .ai-overlay-header-{{ ai_gen_id }} .header__icon:focus-visible svg [stroke]:not([stroke='none']) {
+    stroke: url(#rainbow-gradient) !important;
   }
 
   .ai-overlay-header-hamburger-{{ ai_gen_id }} {
@@ -489,6 +520,7 @@
 
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-icon-{{ ai_gen_id }} {
       --ai-overlay-header-icon-base-color: {{ block.settings.search_icon_color_desktop }};
+      --icon-base: var(--ai-overlay-header-icon-base-color);
       color: var(--ai-overlay-header-icon-base-color);
       position: relative;
       display: inline-flex;
@@ -498,16 +530,19 @@
 
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-account-icon-{{ ai_gen_id }} {
       --ai-overlay-header-icon-base-color: {{ block.settings.account_icon_color_desktop }};
+      --icon-base: var(--ai-overlay-header-icon-base-color);
       color: var(--ai-overlay-header-icon-base-color);
     }
 
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-search-icon-{{ ai_gen_id }} {
       --ai-overlay-header-icon-base-color: {{ block.settings.search_icon_color_desktop }};
+      --icon-base: var(--ai-overlay-header-icon-base-color);
       color: var(--ai-overlay-header-icon-base-color);
     }
 
     .ai-overlay-header-actions-desktop-{{ ai_gen_id }} .ai-overlay-header-cart-icon-{{ ai_gen_id }} {
       --ai-overlay-header-icon-base-color: {{ block.settings.cart_icon_color_desktop }};
+      --icon-base: var(--ai-overlay-header-icon-base-color);
       color: var(--ai-overlay-header-icon-base-color);
     }
 
@@ -515,21 +550,45 @@
 {% endstyle %}
 
 <overlay-header-{{ ai_gen_id }} class="ai-overlay-header-{{ ai_gen_id }}" {{ block.shopify_attributes }}>
-  <svg style="display: none;" aria-hidden="true" focusable="false">
+  <svg class="rainbow-defs" width="0" height="0" aria-hidden="true" focusable="false">
     <defs>
-      <linearGradient id="rainbow-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#ff0000" />
-        <stop offset="9%" stop-color="#ff8000" />
-        <stop offset="18%" stop-color="#ffff00" />
-        <stop offset="27%" stop-color="#80ff00" />
-        <stop offset="36%" stop-color="#00ff00" />
-        <stop offset="45%" stop-color="#00ff80" />
-        <stop offset="54%" stop-color="#00ffff" />
-        <stop offset="63%" stop-color="#0080ff" />
-        <stop offset="72%" stop-color="#0000ff" />
-        <stop offset="81%" stop-color="#8000ff" />
-        <stop offset="90%" stop-color="#ff00ff" />
-        <stop offset="100%" stop-color="#ff0080" />
+      <linearGradient id="rainbow-gradient" x1="0%" y1="0%" x2="200%" y2="0%">
+        <stop offset="0%" stop-color="#ff0000">
+          <animate attributeName="offset" values="0;1" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="9%" stop-color="#ff8000">
+          <animate attributeName="offset" values="0.09;1.09" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="18%" stop-color="#ffff00">
+          <animate attributeName="offset" values="0.18;1.18" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="27%" stop-color="#80ff00">
+          <animate attributeName="offset" values="0.27;1.27" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="36%" stop-color="#00ff00">
+          <animate attributeName="offset" values="0.36;1.36" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="45%" stop-color="#00ff80">
+          <animate attributeName="offset" values="0.45;1.45" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="54%" stop-color="#00ffff">
+          <animate attributeName="offset" values="0.54;1.54" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="63%" stop-color="#0080ff">
+          <animate attributeName="offset" values="0.63;1.63" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="72%" stop-color="#0000ff">
+          <animate attributeName="offset" values="0.72;1.72" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="81%" stop-color="#8000ff">
+          <animate attributeName="offset" values="0.81;1.81" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="90%" stop-color="#ff00ff">
+          <animate attributeName="offset" values="0.9;1.9" dur="2s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="100%" stop-color="#ff0080">
+          <animate attributeName="offset" values="1;2" dur="2s" repeatCount="indefinite" />
+        </stop>
       </linearGradient>
     </defs>
   </svg>


### PR DESCRIPTION
## Summary
- replace the icon hover styling with SVG-based gradient fills so schema hover colors no longer override the rainbow animation
- embed a shared hidden SVG gradient with animated stops and reuse it for all header icons on hover and focus states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e62ead1a048328bbb59a55f3662a81